### PR TITLE
Fix footer position on blog/404 + variable brand colour

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,5 +3,5 @@ title: Not Found
 description: This page doesn't exist!
 image: https://source.unsplash.com/BcoGknSqlDc/2000x1322?a=.png
 permalink: /404.html
-layout: page
+layout: fullpage
 ---

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<!-- <section class="hero" style="background-image: url(https://source.unsplash.com/MqJX_8EaStM/2000x1322)"> -->
+<div class="full">
 <section class="hero">
 	<div class="inner-hero text-container">
 		<div class="hero-text-container">
@@ -21,3 +21,4 @@ layout: default
 		</ul>
 	</div>
 </section>
+</div>

--- a/_layouts/fullpage.html
+++ b/_layouts/fullpage.html
@@ -1,0 +1,15 @@
+---
+layout: default
+---
+
+<!-- <section class="hero" style="background-image: url({% include relative-src.html src=page.image %})"> -->
+<section class="hero full" {% include relative-post-hero.html src=page.image %}>
+		<div class="inner-hero text-container">
+		<div class="hero-text-container">
+			<h1>{{ page.title }}</h1>
+			<p class="subtext">{{ page.description }}</p>
+		</div>
+	</div>
+</section>
+
+{{ content }}

--- a/_sass/landing-page.scss
+++ b/_sass/landing-page.scss
@@ -3,7 +3,7 @@
 	text-align: center;
 	height: 45vh;
 	min-height: 550px;
-	background: rgba(69,99,221,1);
+	background: $brand-color;
 	background-repeat: no-repeat;
 	background-size: cover;
 	background-position: center center;
@@ -40,6 +40,12 @@
 		position: absolute;
 		right: 0;
 	}
+}
+
+
+.full {
+	min-height: calc(100vh - 53px);
+	background-color: #f9f9f9;
 }
 
 .image {

--- a/_sass/openfaas-landing/landing.scss
+++ b/_sass/openfaas-landing/landing.scss
@@ -107,7 +107,7 @@ footer {
 		width: 100%;
 		height: 100%;
 		position: absolute;
-		background: rgba(69,99,221,1);
+		background: $brand-color;
 		z-index: 2;
 	}
 	#whale {

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -1,4 +1,4 @@
-$brand-color: #6ba1f3;
+$brand-color: rgba(69,99,221,1);
 
 // Breakpoints
 $tablet: "(min-width: 450px)";

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,8 @@ description: Keep up with the latest news.
 image: https://source.unsplash.com/MqJX_8EaStM/2000x1322?a=.png
 ---
 
-<!-- <section class="hero" style="background-image: url({% include relative-src.html src=page.image %})"> -->
+
+<div class="full">
 <section class="hero">
 	<div class="inner-hero text-container">
 		<div class="hero-text-container">
@@ -35,3 +36,4 @@ image: https://source.unsplash.com/MqJX_8EaStM/2000x1322?a=.png
 		{% endif %}
 	</div>
 </section>
+</div>

--- a/css/openfaas.scss
+++ b/css/openfaas.scss
@@ -1,5 +1,6 @@
 ---
 ---
+@import "variables";
 @import "openfaas-landing/foundation";
 @import "openfaas-landing/mixins/landing";
 @import "openfaas-landing/fonts";


### PR DESCRIPTION
**NOTE** needs validated on IE/Edge.

This PR updates the blue background to use the `$brand-color` variable.

It also fixes the footer positioning on the blog list page and 404, see following broken/fixed images (note the unwanted whitespace beneath the footer on both pages):

<img width="1205" alt="screen shot 2018-07-24 at 20 22 14" src="https://user-images.githubusercontent.com/83862/43161182-48040d9e-8f7f-11e8-911a-de1419c46b27.png">

<img width="1177" alt="screen shot 2018-07-24 at 20 18 18" src="https://user-images.githubusercontent.com/83862/43161116-16b09b2c-8f7f-11e8-9fa2-db48704a0e7d.png">

<img width="1209" alt="screen shot 2018-07-24 at 20 23 14" src="https://user-images.githubusercontent.com/83862/43161230-6be0d904-8f7f-11e8-85a8-d11af6f9d710.png">

<img width="1192" alt="screen shot 2018-07-24 at 20 18 57" src="https://user-images.githubusercontent.com/83862/43161133-23d603dc-8f7f-11e8-812e-a6bac4d95e1f.png">