### PR TITLE
Toggleable dark background for post titles

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,8 +6,8 @@ layout: default
 <section class="hero" {% include relative-post-hero.html src=page.image %}>
 		<div class="inner-hero text-container">
 		<div class="hero-text-container">
-			<h1>{{ page.title }}</h1>
-			<p class="subtext">{{ page.description }}</p>
+			<h1><span{% if page.darkbackground %} class="dark-background-title"{% endif %}>{{ page.title }}</span></h1>
+			<p class="subtext"><span{% if page.darkbackground %} class="dark-background-description"{% endif %}>{{ page.description }}</span></p>
 		</div>
 	</div>
 </section>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,8 +6,8 @@ layout: default
 <section class="hero" {% include relative-post-hero.html src=page.image %}>
 		<div class="inner-hero text-container">
 		<div class="hero-text-container">
-			<h1><span{% if page.darkbackground %} class="dark-background-title"{% endif %}>{{ page.title }}</span></h1>
-			<p class="subtext"><span{% if page.darkbackground %} class="dark-background-description"{% endif %}>{{ page.description }}</span></p>
+			<h1><span{% if page.dark_background %} class="dark-background-title"{% endif %}>{{ page.title }}</span></h1>
+			<p class="subtext"><span{% if page.dark_background %} class="dark-background-description"{% endif %}>{{ page.description }}</span></p>
 		</div>
 	</div>
 </section>

--- a/_posts/2018-08-01-gke-multi-stage.md
+++ b/_posts/2018-08-01-gke-multi-stage.md
@@ -8,7 +8,7 @@ categories:
   - kubernetes
   - gke
 author_staff_member: stefan
-darkbackground: true
+dark_background: true
 ---
 
 This is a guide on how to set up OpenFaaS on Google Kubernetes Engine (GKE) with a cost-effective, auto-scaling, multi-stage deployment.

--- a/_posts/2018-08-01-gke-multi-stage.md
+++ b/_posts/2018-08-01-gke-multi-stage.md
@@ -8,6 +8,7 @@ categories:
   - kubernetes
   - gke
 author_staff_member: stefan
+darkbackground: true
 ---
 
 This is a guide on how to set up OpenFaaS on Google Kubernetes Engine (GKE) with a cost-effective, auto-scaling, multi-stage deployment.

--- a/_sass/landing-page.scss
+++ b/_sass/landing-page.scss
@@ -34,6 +34,14 @@
 		h1, h2, p, .button {
 			text-shadow: 1px 1px 1px rgba(0,0,0,.8);
 		}
+
+		.dark-background-title {
+			background-color: rgba(0,0,0,0.5);
+		}
+
+		.dark-background-description {
+			background-color: rgba(0,0,0,0.8);
+		}
 	}
 
 	.hero-text-right {


### PR DESCRIPTION
This commit allows the following to be set in the YAML Front Matter which will turn on span background colouring for a post title and description.

    darkbackground: true

<img width="926" alt="screen shot 2018-08-22 at 14 10 13" src="https://user-images.githubusercontent.com/83862/44465328-27611d00-a615-11e8-9490-52f8d0a154b0.png">