### PR TITLE
Render hero full-height pre mid-point

### DIFF
--- a/_sass/landing-page.scss
+++ b/_sass/landing-page.scss
@@ -1,12 +1,17 @@
 .hero {
 	color: #f9f9f9;
 	text-align: center;
-	height: 45vh;
-	min-height: 550px;
 	background: $brand-color;
 	background-repeat: no-repeat;
 	background-size: cover;
 	background-position: center center;
+	min-height: 100%;
+	height: 100vh;
+
+	@media #{$mid-point} {
+		height: 45vh;
+		min-height: 550px;
+	}
 
 	&:before {
 		content: "";
@@ -33,6 +38,14 @@
 
 		h1, h2, p, .button {
 			text-shadow: 1px 1px 1px rgba(0,0,0,.8);
+		}
+
+		.dark-background-title {
+			background-color: rgba(0,0,0,0.5);
+		}
+
+		.dark-background-description {
+			background-color: rgba(0,0,0,0.8);
 		}
 	}
 


### PR DESCRIPTION
This PR alters the rendering behaviour of the hero so that it renders full height pre- the 620px midpoint. This avoids the overflow issue seen on mobile with post titles/descriptions.

Desktop remains unchanged.

<img width="1106" alt="screen shot 2018-08-24 at 08 06 09" src="https://user-images.githubusercontent.com/83862/44570132-b3d62180-a774-11e8-9e4b-5f2f1a9e46cc.png">

Mobile renders the hero (on both the post landing page and post pages themselves) full height (this is the themes original behaviour).

![overflow-mobile-fix](https://user-images.githubusercontent.com/83862/44570218-fa2b8080-a774-11e8-8a38-921c4a29e3b6.gif)

**NOTE** - some common sense still needs to be taken with titles/descriptions to ensure they are concise and not overly long.