### PR TITLE
Fix hover states for menu items

### DIFF
--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -42,6 +42,10 @@ nav {
 			color: rgba(255,255,255,.8);
 		}
 
+		&:hover {
+			color: inherit;
+			opacity: 0.5;
+		}
 
 		&.nav-toggle {
 			display: inline;


### PR DESCRIPTION
Currently, when you hover over the nav links, they go blue (against a blue background!). This fixes that, and because we're using `color: inherit`, it'll work with whichever color you choose in future, and we don't have to define different hover states for different breakpoints.