### PR TITLE
Anchor links broken [Fixes #32]

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ description: Serverless Functions Made Simple for Docker and Kubernetes.
 							<h3>Hi, I’m Alex Ellis</h3>
 							<p>I'm the founder of OpenFaaS &reg;. I made the first commit to the project in Dec 2016 and since then have built up a thriving global community with over a hundred contributors.</p>
 							<p>The values of the project are: developer-first, operational simplicity and being community-centric.</p>
-							<p>A team of <a href="https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md">core contributors</a>, <a href="https://github.com/orgs/openfaas/people">members</a> and <a href="https://docs.openfaas.com/">end-users</a> are helping me shape the direction and future of the project.</p>
+							<p>A team of <a href="https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md">core contributors</a>, <a href="https://github.com/orgs/openfaas/people">members</a> and <a href="https://docs.openfaas.com/#users-of-openfaas">end-users</a> are helping me shape the direction and future of the project.</p>
 							<p>Read my latest blogs and tutorials over at <a href="https://blog.alexellis.io">blog.alexellis.io</a></p>
 						</div>
 						<div class="cell large-12">

--- a/js/main.js
+++ b/js/main.js
@@ -26,12 +26,4 @@
 		document.body.classList.toggle("nav-open");
 		changeHeader();
 	});
-
-	$("a[href*=\\#]").on("click", function (event) {
-		event.preventDefault();
-
-		$("html, body").animate({
-			scrollTop: $(this.hash).offset().top
-		}, 500);
-	});
 })();


### PR DESCRIPTION
This fixes #32.

- Reverts change to anchored link in `index.html`
- Removes unused intercept of `#` links, this feature of the template was not being used so has been removed.

Have tested locally on web and mobile.