### PR TITLE
Fix microservice post formatting + add code highlighting

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,6 +17,7 @@
 		<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,400">
 
 		<link rel="stylesheet" href="{{ site.baseurl }}/css/screen.css">
+		<link rel="stylesheet" href="{{ site.baseurl }}/css/highlighter/gruvbox.light.css">
 		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 
 		{% if jekyll.environment == 'production' and site.google_analytics_key != '' %}

--- a/_posts/2018-09-06-stateless-microservices.md
+++ b/_posts/2018-09-06-stateless-microservices.md
@@ -156,7 +156,7 @@ Notes on [OpenFaaS workloads](https://docs.openfaas.com/reference/workloads/):
 
 `./frank-says/Gemfile`:
 
-```Gemfile
+```ruby
 source 'https://rubygems.org'
 gem "sinatra"
 ```
@@ -165,7 +165,7 @@ Any list of gems can be added in this file.
 
 Now replace the `./frank-says/Dockerfile` with:
 
-```Dockerfile
+```dockerfile
 FROM ruby:2.4-alpine3.6
 WORKDIR /home/app
 COPY    .   .

--- a/_posts/2018-09-06-stateless-microservices.md
+++ b/_posts/2018-09-06-stateless-microservices.md
@@ -56,7 +56,7 @@ If you've written at least one serverless function then you'll be aware that the
 
 Here's an example of a Node.js function:
 
-```
+```js
 "use strict"
 
 module.exports = (context, callback) => {
@@ -200,7 +200,7 @@ $ docker login
 
 * Run the `up` command which is an alias for `build`, `push` and `deploy`.
 
-```
+```bash
 $ faas-cli up --yaml frank-says.yml
 
 Deploying: frank-says.
@@ -218,7 +218,7 @@ Frank has entered the building.
 
 You can also try a custom route:
 
-```
+```bash
 $ curl http://127.0.0.1:8080/function/frank-says/logout
 Frank has left the building.
 ```
@@ -227,7 +227,7 @@ You can try updating the messages or adding some other routes then run `faas-cli
 
 Now check out `faas-cli list` to see the invocation count rising each time you access the microservice.
 
-```
+```bash
 $ faas-cli list
 Function                        Invocations     Replicas
 frank-says                      5               1
@@ -237,7 +237,7 @@ frank-says                      5               1
 
 We can now trigger auto-scaling with a simple bash `for` loop:
 
-```
+```bash
 $ for i in {1..10000}
 do
   sleep 0.01 \
@@ -250,7 +250,7 @@ In another window enter: `watch faas-cli list` or run `faas-cli list` periodical
 
 ```
 Function                        Invocations     Replicas
-frank-says                    	702            	4 
+frank-says                      702             4
 ```
 
 When your bash `for` loop completes or when you cancel it with Ctrl+C you will see the replica count decrease back to `1`.
@@ -263,20 +263,20 @@ Read more on auto-scaling including how to [configure min, max and zero replica 
 
 ### Deploy the Sinatra guestbook with MySQL
 
-```
+```bash
 $ git clone https://github.com/openfaas-incubator/openfaas-sinatra-guestbook \
   && cd openfaas-sinatra-guestbook
 ```
 
 Configure your MySQL database details in `./sql.yml`. If you don't have access to MySQL you can deploy it within a few minutes using [helm](https://github.com/helm/charts/tree/master/stable/mysql) on Kubernetes or `docker run` and the official [Docker Image](https://hub.docker.com/_/mysql/).
 
-```
+```bash
 $ cp sql.example.yml sql.yml
 ```
 
 Finally deploy the guestbook:
 
-```
+```bash
 $ faas-cli up
 
 http://127.0.0.1:8080/function/guestbook
@@ -296,7 +296,7 @@ To enable [scaling to zero](https://www.openfaas.com/blog/zero-scale/) simply [f
 
 Then add a label to your `stack.yml` file to tell OpenFaaS that your function is eligible for zero-scaling:
 
-```
+```yaml
     labels:
       com.openfaas.scale.zero: true
 ```

--- a/_sass/blog.scss
+++ b/_sass/blog.scss
@@ -117,7 +117,7 @@
 			word-wrap: break-word;
 		}
 
-		h2, h3 {
+		h2, h3, h4 {
 			font-family: "Open Sans", sans-serif;
 			font-feature-settings: "dlig", "liga", "lnum", "kern";
 			text-rendering: geometricPrecision;
@@ -134,6 +134,14 @@
 
 		h3 {
 			font-size: 30px;
+			font-weight: 700;
+			letter-spacing: -0.6px;
+			line-height: 34.5px;
+			margin-bottom: 12px;
+		}
+
+		h4 {
+			font-size: 24px;
 			font-weight: 700;
 			letter-spacing: -0.6px;
 			line-height: 34.5px;

--- a/css/highlighter/gruvbox.light.css
+++ b/css/highlighter/gruvbox.light.css
@@ -1,0 +1,84 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight, .highlight .w {
+  color: #282828;
+  background-color: #fbf1c7;
+}
+.highlight .err {
+  color: #9d0006;
+  background-color: #fbf1c7;
+  font-weight: bold;
+}
+.highlight .c, .highlight .cd, .highlight .cm, .highlight .c1, .highlight .cs {
+  color: #928374;
+  font-style: italic;
+}
+.highlight .cp {
+  color: #427b58;
+}
+.highlight .nt {
+  color: #9d0006;
+}
+.highlight .o, .highlight .ow {
+  color: #282828;
+}
+.highlight .p, .highlight .pi {
+  color: #282828;
+}
+.highlight .gi {
+  color: #79740e;
+  background-color: #fbf1c7;
+}
+.highlight .gd {
+  color: #9d0006;
+  background-color: #fbf1c7;
+}
+.highlight .gh {
+  color: #79740e;
+  font-weight: bold;
+}
+.highlight .k, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kv {
+  color: #9d0006;
+}
+.highlight .kc {
+  color: #8f3f71;
+}
+.highlight .kt {
+  color: #b57614;
+}
+.highlight .kd {
+  color: #af3a03;
+}
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2, .highlight .sh, .highlight .sx, .highlight .s1 {
+  color: #79740e;
+  font-style: italic;
+}
+.highlight .si {
+  color: #79740e;
+  font-style: italic;
+}
+.highlight .sr {
+  color: #79740e;
+  font-style: italic;
+}
+.highlight .se {
+  color: #af3a03;
+}
+.highlight .nn {
+  color: #427b58;
+}
+.highlight .nc {
+  color: #427b58;
+}
+.highlight .no {
+  color: #8f3f71;
+}
+.highlight .na {
+  color: #79740e;
+}
+.highlight .m, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo, .highlight .mb, .highlight .mx {
+  color: #8f3f71;
+}
+.highlight .ss {
+  color: #076678;
+}


### PR DESCRIPTION
This Closes #36, This Closes #9 

- Fixes languages for broken code blocks, you must use lowercase, and `Gemfile` isn't a valid choice - replaced with `ruby`
- Styles the h4 element.

<img width="681" alt="screen shot 2018-10-04 at 01 28 03" src="https://user-images.githubusercontent.com/83862/46446544-c3ce2180-c774-11e8-9a23-dcf363f81a4d.png">

- Adds code block styling using Rouge and the gruvbox.light theme

<img width="783" alt="screen shot 2018-10-04 at 02 20 35" src="https://user-images.githubusercontent.com/83862/46447870-1a8b2980-c77c-11e8-91e3-d891417379a2.png">
