### PR TITLE
Change DigitalOcean logo on Ansible blog to #0069ff

### DIFF
--- a/images/deploy-digitalocean-ansible/digital_ocean.svg
+++ b/images/deploy-digitalocean-ansible/digital_ocean.svg
@@ -1,6 +1,6 @@
 <svg width="900" height="174" xmlns="http://www.w3.org/2000/svg">
- <style type="text/css">.st0{fill:#000000;}
-	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#000000;}</style>
+ <style type="text/css">.st0{fill:#0069ff;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#0069ff;}</style>
 
  <g>
   <title>background</title>


### PR DESCRIPTION
Changes the DigitalOcean logo on Ansible blog from #000000 (black) to #0069ff (DigitalOcean blue)

Signed-off-by: Richard Gee <richard@technologee.co.uk>