### PR TITLE
Fix typo on list secrets

### DIFF
--- a/_posts/2019-01-24-unified-secrets.md
+++ b/_posts/2019-01-24-unified-secrets.md
@@ -129,7 +129,7 @@ Now verify it:
 ```bash
 # Customise to http/https as needed
 curl -X GET \
-  http://admin:password@$GATEWAY/system/list
+  http://admin:password@$GATEWAY/system/secrets
 ```
 
 ## Let's put it all together


### PR DESCRIPTION

Fix typo on request path when listing secrets

Signed-off-by: Ruan Bekker <ruan.ru.bekker@gmail.com>