### PR TITLE
Change /donate/ page to /support/

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -82,7 +82,7 @@ defaults:
       layout: "default"
   -
     scope:
-      path: "donate"
+      path: "support"
     values:
       layout: "default"
   -

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -12,6 +12,6 @@
   link: https://docs.openfaas.com/
 - name: Video Demo
   class: navbar-item start-demo-video
-- name: Donate
+- name: Support
   class: navbar-item
-  link: /donate/
+  link: /support/

--- a/_includes/landing-page/landing-sponsors.html
+++ b/_includes/landing-page/landing-sponsors.html
@@ -30,7 +30,7 @@
             </div>
         {% endfor %}
         <div class="column is-12 has-text-centered">
-            <a href="{{ site.baseurl }}/donate" class="button is-large">
+            <a href="{{ site.baseurl }}/support" class="button is-large">
                 Become a sponsor
                 <span class="icon">
                     <i class="fas fa-long-arrow-alt-right"></i>

--- a/_posts/2019-05-10-meet-us-at-barcelona.md
+++ b/_posts/2019-05-10-meet-us-at-barcelona.md
@@ -57,7 +57,7 @@ We'll be organizing a face-to-face at a local cafe or bar, so if you want to be 
 
 ## Wrapping up
 
-Are you using OpenFaaS in production? [Join the end-user community](https://github.com/openfaas/faas/issues/776) or [sponsor the project](https://www.openfaas.com/donate/) to give back and show your appreciation.
+Are you using OpenFaaS in production? [Join the end-user community](https://github.com/openfaas/faas/issues/776) or [sponsor the project](https://www.openfaas.com/support/) to give back and show your appreciation.
 
 If you have comments, questions or suggestions or would like to join the community, then please [join us on OpenFaaS Slack](https://docs.openfaas.com/community/).
 

--- a/support/index.html
+++ b/support/index.html
@@ -1,5 +1,5 @@
 ---
-title: Donate and pledge
+title: Support and pledge
 description: Support the on-going Open Source development and activities of the OpenFaaS community
 image: https://www.openfaas.com/images/pexels-gathering.jpg
 ---
@@ -7,7 +7,7 @@ image: https://www.openfaas.com/images/pexels-gathering.jpg
 <section class="hero donate-page-title">
     <div class="hero-body has-text-centered intro">
         <h1 class="title is-size-3 is-size-2-desktop has-text-grey-darker">
-            Donate
+            Support
         </h1>
         <h1 class="title is-size-5 is-size-4-desktop has-text-grey-darker has-text-weight-light">
             Support the ongoing development and independence of OpenFaaS


### PR DESCRIPTION
As requested, changes donate to support on landing page, also includes references from other pages, using same SCSS.

<img width="1397" alt="Screenshot 2019-05-22 at 15 37 15" src="https://user-images.githubusercontent.com/83862/58178972-81c40280-7ca7-11e9-8509-0bfcf9c6a08d.png">

<img width="1402" alt="Screenshot 2019-05-22 at 15 37 20" src="https://user-images.githubusercontent.com/83862/58178978-838dc600-7ca7-11e9-94af-e0563d9c4a41.png">

