### PR TITLE
Fix W3C Validation errors

### DIFF
--- a/_includes/footer-navigation.html
+++ b/_includes/footer-navigation.html
@@ -2,7 +2,7 @@
     <div class="container is-fluid">
         <div class="navbar-brand">
             <a class="navbar-item" href="{{ site.baseurl }}/">
-                <img src="{{ site.baseurl }}/images/openfaas/footer-of-logo.png">
+                <img src="{{ site.baseurl }}/images/openfaas/footer-of-logo.png" alt="logo">
             </a>
             <p class="navbar-item is-size-5 is-size-4-fullhd has-text-weight-bold is-hidden-mobile">Serverless Functions, Made Simple.</p>
         </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
 			<div class="footer-wrapper-right">
                 <a href="https://landscape.cncf.io/format=serverless">
                     <small>Featured on</small>
-                    <img src="{{ site.baseurl }}/images/openfaas/cloud-native.png">
+                    <img src="{{ site.baseurl }}/images/openfaas/cloud-native.png" alt="CNCF Logo">
                 </a>
 			</div>
 		</div>

--- a/_includes/landing-page/landing-description.html
+++ b/_includes/landing-page/landing-description.html
@@ -20,7 +20,7 @@
                 <div class="column is-12 is-spaced-bottom">
                     <div class="columns">
                         <div class="column is-3-tablet is-narrow-desktop has-text-centered-mobile">
-                            <p><img src="{{ site.baseurl }}/images/openfaas/store.svg"></p>
+                            <p><img src="{{ site.baseurl }}/images/openfaas/store.svg" alt="Function Store"></p>
                         </div>
                         <div class="column">
                             <h1 class="title is-size-4 has-text-grey-darker">
@@ -35,7 +35,7 @@
                 <div class="column is-12 is-spaced-bottom">
                     <div class="columns">
                         <div class="column is-3-tablet is-narrow-desktop has-text-centered-mobile">
-                            <p><img src="{{ site.baseurl }}/images/openfaas/template.svg"></p>
+                            <p><img src="{{ site.baseurl }}/images/openfaas/template.svg" alt="Reduce Boilerplating"></p>
                         </div>
                         <div class="column">
                             <h1 class="title is-size-4 has-text-grey-darker">
@@ -50,7 +50,7 @@
                 <div class="column is-12 is-spaced-bottom">
                     <div class="columns">
                         <div class="column is-3-tablet is-narrow-desktop has-text-centered-mobile">
-                            <p><img src="{{ site.baseurl }}/images/openfaas/functions.svg"></p>
+                            <p><img src="{{ site.baseurl }}/images/openfaas/functions.svg" alt="Functions and Microservices"></p>
                         </div>
                         <div class="column">
                             <h1 class="title is-size-4 has-text-grey-darker">

--- a/_includes/landing-page/landing-features.html
+++ b/_includes/landing-page/landing-features.html
@@ -3,7 +3,7 @@
         <div class="column is-12-tablet is-4-desktop">
             <div class="columns is-multiline feature-box">
                 <div class="column is-narrow" style="width: 170px;">
-                    <img src="{{ site.baseurl }}/images/openfaas/anywhere.svg">
+                    <img src="{{ site.baseurl }}/images/openfaas/anywhere.svg" alt="Run anywhere">
                 </div>
                 <div class="column has-text-centered-mobile">
                     <h1 class="title is-size-4 has-text-grey-darker">
@@ -18,7 +18,7 @@
         <div class="column is-12-tablet is-4-desktop">
             <div class="columns is-multiline feature-box">
                 <div class="column is-narrow" style="width: 150px;">
-                    <img src="{{ site.baseurl }}/images/openfaas/anycode.svg">
+                    <img src="{{ site.baseurl }}/images/openfaas/anycode.svg" alt="Any code">
                 </div>
                 <div class="column has-text-centered-mobile">
                     <h1 class="title is-size-4 has-text-grey-darker">
@@ -33,7 +33,7 @@
         <div class="column is-12-tablet is-4-desktop">
             <div class="columns is-multiline feature-box">
                 <div class="column is-narrow" style="width: 150px;">
-                    <img src="{{ site.baseurl }}/images/openfaas/anyscale.svg">
+                    <img src="{{ site.baseurl }}/images/openfaas/anyscale.svg" alt="Any scale">
                 </div>
                 <div class="column has-text-centered-mobile">
                     <h1 class="title is-size-4 has-text-grey-darker">

--- a/_includes/landing-page/landing-intro.html
+++ b/_includes/landing-page/landing-intro.html
@@ -1,6 +1,6 @@
 <div class="container">
 	<p class="intro-logo">
-		<img src="{{ site.baseurl }}/images/openfaas/whale.png">
+		<img src="{{ site.baseurl }}/images/openfaas/whale.png" alt="logo">
 	</p>
 </div>
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -2,7 +2,7 @@
     <div class="container is-fluid">
         <div class="navbar-brand">
             <a class="navbar-item" href="{{ site.baseurl }}/">
-                <img src="{{ site.baseurl }}/images/openfaas_light.png">
+                <img src="{{ site.baseurl }}/images/openfaas_light.png" alt="Title Image">
             </a>
 
             <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,12 +13,10 @@
 	<link rel="icon" type="image/png" href="{{ site.baseurl }}/touch-icon.png" sizes="192x192">
 	<link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicon.png">
 
-	<link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900|Rubik:300,400,500,700,900" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900%7CRubik:300,400,500,700,900" rel="stylesheet">
 	<link rel="stylesheet" href="{{ site.baseurl }}/css/openfaas.css">
 
-	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable = yes">
-	<title>OpenFaaS - Serverless Functions Made Simple</title>
 
     <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
 

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -13,12 +13,10 @@
 	<link rel="icon" type="image/png" href="{{ site.baseurl }}/touch-icon.png" sizes="192x192">
 	<link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicon.png">
 
-	<link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900|Rubik:300,400,500,700,900" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900%7CRubik:300,400,500,700,900" rel="stylesheet">
 	<link rel="stylesheet" href="{{ site.baseurl }}/css/openfaas.css">
 
-	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable = yes">
-	<title>OpenFaaS - Serverless Functions Made Simple</title>
 
     <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -26,7 +26,7 @@ image: https://source.unsplash.com/MqJX_8EaStM/2000x1322?a=.png
                         <a href="{{ site.baseurl }}{{ paginator.previous_page_path }}" class="pagination-previous">Newer posts</a>
                     {% endif %}
                     {% if paginator.next_page %}
-                        <a href="{{ site.baseurl }}{{ paginator.next_page_path }}"class="pagination-next">Older posts</a>
+                        <a href="{{ site.baseurl }}{{ paginator.next_page_path }}" class="pagination-next">Older posts</a>
                     {% endif %}
                     <ul class="pagination-list">
                         <li>


### PR DESCRIPTION
As part of investigating the issue whereby LinkedIn is choosing not to use the og:image meta tag there have been mentions that invalid HTML may also affect the LinkedIn parser's ability to accurately parse the page.

Having run the homepage through https://validator.w3.org a number of errors were highighlighted.  This change aims to address those errors.

Signed-off-by: Richard Gee <richard@technologee.co.uk>