### PR TITLE
Update wording on homepage - remove swarm

### DIFF
--- a/_includes/landing-page/landing-description.html
+++ b/_includes/landing-page/landing-description.html
@@ -2,12 +2,13 @@
     <div class="columns is-multiline">
         <div class="column is-12-tablet is-6-desktop is-spaced-bottom">
             <h1 class="title is-size-3-tablet is-size-2-desktop has-text-grey-darker">
-                Run functions anywhere enabling you with the same unified experience.
+                Run your code anywhere with the same unified experience.
             </h1>
             <h1 class="title has-text-weight-light is-size-5 is-size-4-desktop has-text-grey">
                 Bring your laptop, your own on-prem hardware or create a cluster in the cloud.
-                Pick Kubernetes or Docker to do the heavy lifting enabling you to build a scalable,
+                Let Kubernetes do the heavy lifting enabling you to build a scalable,
                 fault-tolerant event-driven serverless platform for your applications.
+
             </h1>
             <h1 class="title has-text-weight-light is-size-5 is-size-4-desktop has-text-grey">
                 You can try out OpenFaaS in 60 seconds or write and deploy your first Python function in around 10-15 minutes.

--- a/_includes/landing-page/landing-intro.html
+++ b/_includes/landing-page/landing-intro.html
@@ -9,7 +9,6 @@
 		Serverless Functions, Made Simple.
 	</h1>
 	<h1 class="is-size-5-mobile is-size-4-tablet is-size-3-desktop has-text-weight-light">
-		OpenFaaS® makes it simple to turn anything into a serverless function <br>
-		that runs on Linux or Windows through Docker Swarm or Kubernetes.
+		OpenFaaS® makes it simple to deploy both functions and existing code to Kubernetes
 	</h1>
 </div>


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>


Wording change to remove swarm and change a few other bits.

See screenshots:

<img width="1166" alt="Screenshot 2019-11-21 at 18 35 45" src="https://user-images.githubusercontent.com/40488132/69366266-eaf3f500-0c8d-11ea-9ddc-3152f78d8564.png">
<img width="643" alt="Screenshot 2019-11-21 at 18 35 40" src="https://user-images.githubusercontent.com/40488132/69366267-eb8c8b80-0c8d-11ea-8ab5-0c67bae76d1f.png">
