### PR TITLE
Add OF image to blog social media preview

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,7 +1,7 @@
 ---
 title: Blog
 description: Keep up with the latest OpenFaaS news.
-image: https://source.unsplash.com/MqJX_8EaStM/2000x1322?a=.png
+image: /images/preview_image.png
 ---
 
 <section class="hero is-primary is-small">


### PR DESCRIPTION
Addendum to #140 and #85 to update the social media preview image for the blog index page.

Images on the blog articles themselves remain unchanged.

Signed-off-by: Richard Gee <richard@technologee.co.uk>