### PR TITLE
Remove Richard from the team page

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -3,7 +3,6 @@ founders:
   - alex
 
 core:
-  - richard
   - stefan
   - burton
   - lucas

--- a/_staff_members/richard.md
+++ b/_staff_members/richard.md
@@ -1,10 +1,10 @@
 ---
 name: Richard Gee
-position: Core Contributor
+position: Other
 image_path: /images/author/richard.png
 twitter_username: rgee0
 github_username: rgee0
 linkedin_username: rgee0
 webpage: https://blog.technologee.co.uk/
-blurb: Core Contributor <a href="https://twitter.com/openfaas">@openfaas</a>.
+blurb: Guest writer, formerly a Core Contributor.
 ---


### PR DESCRIPTION
Removes Richard from the members page.
Changes Richard's blurb so that the two blog articles have an accurate profile/footer.

Signed-off-by: Richard Gee <richard@technologee.co.uk>