### PR TITLE
Expand the max width of the blog post page

### DIFF
--- a/_sass/openfaas/includes/blog-page/post-page.scss
+++ b/_sass/openfaas/includes/blog-page/post-page.scss
@@ -1,6 +1,6 @@
 .post-page-full {
     .container {
-        max-width: 750px;
+        max-width: 1000px;
         font-size: 20px;
 
         >h1.title,


### PR DESCRIPTION
When we put code snippets in they always end up with a massive
overflow, and long scroll bar. We can set the max-width for blog
posts wider so where people have the screen for it we expand out
sideways a bit more.

## AFTER

Web:
![image](https://user-images.githubusercontent.com/40488132/73554518-c6618980-4443-11ea-8066-ca50220abc7b.png)




Mobile:
![Screenshot_20200131-160132_Firefox](https://user-images.githubusercontent.com/40488132/73554448-a631ca80-4443-11ea-9904-8beb110657aa.jpg)

## Before

Web
![image](https://user-images.githubusercontent.com/40488132/73554554-dda07700-4443-11ea-98bc-515592a73082.png)


(mobile un-changed)
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>
