### PR TITLE
Remove expired sponsor from homepage

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -6,9 +6,10 @@ platinum:
 - alt: "DigitalOcean"
   url: https://digitalocean.com/
   logo: digitalocean.svg
-- alt: "Rancher Labs"
-  url: https://rancher.com/
-  logo: rancher-logo-stacked-color.svg
+# Expired Jan 2020
+# - alt: "Rancher Labs"
+#   url: https://rancher.com/
+#   logo: rancher-logo-stacked-color.svg
 - alt: "DX"
   url: https://dx.no/
   logo: dx.png


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

The sponsorship from Rancher Labs has expired and will need to be removed if not renewed.

Alex