### PR TITLE
Remove the Category Archive link generation

### DIFF
--- a/_includes/blog-page/post-title.html
+++ b/_includes/blog-page/post-title.html
@@ -2,7 +2,7 @@
 	<span class="post-date is-pulled-right">{{ include.post.date | date: "%B %d, %Y" }}</span>
 	{% for category in include.post.categories %}
 		<span class="tag">
-			<a href="{{ site.baseurl }}/category/{{ category | slugify }}/">{{ category | capitalize }}</a>
+			{{ category | capitalize }}
 		</span>
 	{% endfor %}
 </h2>


### PR DESCRIPTION
The link generation I put in for archives recently isn't supported on
github pages :(

https://github.com/github/pages-gem/pull/643
https://github.com/jekyll/minima/issues/463

Removed the links for categories now, can be put back in as links if
github ever gets implemented

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>