### PR TITLE
Civo cancelled their sponsorship today

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -20,9 +20,10 @@ platinum:
   url: https://akash.network
   logo: akash.svg
 gold:
-- alt: "Civo: UK Cloud Hosting Platform"
-  url: https://www.civo.com/promo
-  logo: civo.svg
+# Cancelled due to Coronavirus :-/
+#- alt: "Civo: UK Cloud Hosting Platform"
+#  url: https://www.civo.com/promo
+#  logo: civo.svg
 # For 4 months from Feb
 - alt: "MSB: Kubernetes training that works."
   url: https://www.msb.com


### PR DESCRIPTION
Unfortunately this is owing to the Coronavirus

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>