### PR TITLE
Remove stray bracket in link markdown

### DIFF
--- a/_posts/2019-07-04-python-datascience-with-openfaas.md
+++ b/_posts/2019-07-04-python-datascience-with-openfaas.md
@@ -254,7 +254,7 @@ OpenFaaS can support various machine learning frameworks beyond PyTorch, if you 
 
 * [How to split large Python Functions across multiple files][multifile-blog-post]
 * [Introducing the Template Store for OpenFaaS][template-store-post]
-* [Accelerating the Journey of an AI algorithm to production with openfaas at BT][[kubecon-bt-journey]
+* [Accelerating the Journey of an AI algorithm to production with openfaas at BT][kubecon-bt-journey]
 
 [conda-homepage]: https://docs.conda.io/projects/conda/en/latest/
 [flask-return-values]: http://flask.pocoo.org/docs/1.0/quickstart/#about-responses


### PR DESCRIPTION
**What**
- Remove a stray `[` that prevented the last link from being rendered

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>