### PR TITLE
fix: Duplicate "of" in headline

### DIFF
--- a/_includes/landing-page/landing-contributors.html
+++ b/_includes/landing-page/landing-contributors.html
@@ -2,7 +2,7 @@
     <div class="columns is-multiline">
         <div class="column is-12 is-spaced-bottom has-text-centered has-text-right-desktop">
             <h1 class="title is-size-3 is-size-2-desktop has-text-grey-darker">
-                Meet #TeamServerless - our community of of 270+ contributors
+                Meet #TeamServerless - our community of 270+ contributors
             </h1>
         </div>
 


### PR DESCRIPTION
There was a duplicate "of" in the headline:

"Meet #TeamServerless - our community of of 270+ contributors" -> "Meet #TeamServerless - our community of 270+ contributors"

