### PR TITLE
Update okteto post to reflect new manifest syntax

### DIFF
--- a/images/2020-01-24-painless-serverless-development/okteto.yml
+++ b/images/2020-01-24-painless-serverless-development/okteto.yml
@@ -1,13 +1,10 @@
 # The name tells Okteto to replace the function named 'hello' with the dev environment
 name: hello                  
-image: okteto/golang-http-template
+image: okteto/golang-middleware-template:0.1.1
 command:
 - bash
-workdir: /home/app/handler
-mountpath: /home/app/handler/function
-volumes:
-# This makes the go build cache persistent across development environments
-- /home/app/.cache/go-build/ 
+workdir: /home/app
+mountpath: /home/app/function
 securityContext:
   # the user and group that OpenFaaS functions run as
   runAsUser:  12000
@@ -18,8 +15,7 @@ securityContext:
     # enables us to run the debugger inside the pod
     - SYS_PTRACE
 environment:
-  # overrides the one set by openfaas, enabling hot reload
-  - fprocess=go run main.go
+  # overrides the one set by openfaas, enabling build and run
+  - fprocess=go run /home/app/main.go
 forward:
-- 8080:8080
 - 2345:2345


### PR DESCRIPTION
I'd like to update the okteto post to reflect new manifest syntax (current example is broken on the latest version), and a few minor edits:

- use `faas-cli` for the commands to be consistent with other posts.
- add extra explanation on how the file sync works.

Signed-off-by: Ramiro Berrelleza <rberrelleza@gmail.com>