### PR TITLE
Move ofc-bootstrap into openfaas org

### DIFF
--- a/_posts/2019-03-30-openfaas-cloud-gitlab.md
+++ b/_posts/2019-03-30-openfaas-cloud-gitlab.md
@@ -108,11 +108,11 @@ The `ofc-bootstrap` tool is used to install OpenFaaS Cloud in a single click. Yo
 ```
 mkdir -p ~/dev/ofc/
 cd ~/dev/ofc/
-git clone https://github.com/openfaas-incubator/ofc-bootstrap
+git clone https://github.com/openfaas/ofc-bootstrap
 cd ~/dev/ofc/ofc-bootstrap
 ```
 
-Now fetch the latest release from: [GitHub](https://github.com/openfaas-incubator/ofc-bootstrap/releases) and save it in `/usr/local/bin/`. If you're on MacOS download "ofc-bootstrap-darwin" and save it as "ofc-bootstrap".
+Now fetch the latest release from: [GitHub](https://github.com/openfaas/ofc-bootstrap/releases) and save it in `/usr/local/bin/`. If you're on MacOS download "ofc-bootstrap-darwin" and save it as "ofc-bootstrap".
 
 Run `chmod +x /usr/local/bin/ofc-bootstrap`
 
@@ -208,7 +208,7 @@ If using DigitalOcean, save an access token to:
 
 `ofc-boostrap` will pass the token onto `cert-manager` as a Kubernetes secret.
 
-If you are using GCP or AWS to manage DNS then see the [README.md file](https://github.com/openfaas-incubator/ofc-bootstrap).
+If you are using GCP or AWS to manage DNS then see the [README.md file](https://github.com/openfaas/ofc-bootstrap).
 
 #### Authenticate to your registry
 
@@ -219,7 +219,7 @@ If you don't have an account you can sign-up at: [https://hub.docker.com](https:
 
 You can also [install your own self-hosted registry](https://github.com/alexellis/k8s-tls-registry) for private Docker images. Note: you can self-host a registry on a single-node, or in a different cluster all together if you wish.
 
-> Note: using AWS ECR is beyond the scope of this tutorial. See here for info: [OFC: configuring AWS ECR](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md#prepare-your-docker-registry-if-using-aws-ecr).
+> Note: using AWS ECR is beyond the scope of this tutorial. See here for info: [OFC: configuring AWS ECR](https://github.com/openfaas/ofc-bootstrap/blob/master/USER_GUIDE.md#prepare-your-docker-registry-if-using-aws-ecr).
 
 Now log in, using ofc-bootstrap.
 

--- a/_posts/2019-04-18-spring-easter.md
+++ b/_posts/2019-04-18-spring-easter.md
@@ -121,7 +121,7 @@ Here's a demo of the OpenFaaS Cloud flow in action:
 
 Form: [Request access now](https://forms.gle/8e6ZXJKMcDHpV6Xu6)
 
-If you're experienced with OpenFaaS, then perhaps you'd like to stand-up your own OpenFaaS Cloud with the [ofc-bootstrap tool](https://github.com/openfaas-incubator/ofc-bootstrap)? It takes around 100 seconds to deploy to a Kubernetes service such as [DigitalOcean Kubernetes](https://www.digitalocean.com/products/kubernetes/) or [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/). You'll get the same experience as with the Community Cluster including automatic TLS and support for GitHub.com or GitLab self-hosted.
+If you're experienced with OpenFaaS, then perhaps you'd like to stand-up your own OpenFaaS Cloud with the [ofc-bootstrap tool](https://github.com/openfaas/ofc-bootstrap)? It takes around 100 seconds to deploy to a Kubernetes service such as [DigitalOcean Kubernetes](https://www.digitalocean.com/products/kubernetes/) or [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/). You'll get the same experience as with the Community Cluster including automatic TLS and support for GitHub.com or GitLab self-hosted.
 
 ## Wrapping up
 

--- a/_posts/2019-08-04-plonk-stack.md
+++ b/_posts/2019-08-04-plonk-stack.md
@@ -229,7 +229,7 @@ You can [get Kubernetes](https://kubernetes.io/) from your favourite cloud as a 
 
     In late 2017 I started to design a distribution of OpenFaaS that shipped as a whole package including HTTPS, multi-user support, authz and CI/CD with GitHub and GitLab.
 
-    It's called OpenFaaS Cloud and is free and open-source. You can host your own using the [ofc-bootstrap tool](https://github.com/openfaas-incubator/ofc-bootstrap) or [request free access to the Community Cluster](https://github.com/openfaas/community-cluster/).
+    It's called OpenFaaS Cloud and is free and open-source. You can host your own using the [ofc-bootstrap tool](https://github.com/openfaas/ofc-bootstrap) or [request free access to the Community Cluster](https://github.com/openfaas/community-cluster/).
 
     <blockquote class="twitter-tweet" data-theme="light"><p lang="en" dir="ltr">&quot;OpenFaaS Cloud - Community Cluster&quot;<br><br>A SaaS solution built on OpenFaaS.<br><br>- Free sub-domain and endpoints<br>- TLS by default<br>- Login with GitHub<br>- No complex API or CLI needed, just push to git.<br><br>Apply for access today. 🏆<a href="https://t.co/IGuZGZiPT3">https://t.co/IGuZGZiPT3</a> <a href="https://twitter.com/hashtag/gitops?src=hash&amp;ref_src=twsrc%5Etfw">#gitops</a> <a href="https://twitter.com/hashtag/faasfriday?src=hash&amp;ref_src=twsrc%5Etfw">#faasfriday</a> <a href="https://t.co/pqIMzYsMbI">pic.twitter.com/pqIMzYsMbI</a></p>&mdash; OpenFaaS (@openfaas) <a href="https://twitter.com/openfaas/status/1144621477129379842?ref_src=twsrc%5Etfw">June 28, 2019</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     

--- a/_posts/2019-08-20-serverless-static-sites.md
+++ b/_posts/2019-08-20-serverless-static-sites.md
@@ -272,7 +272,7 @@ I'm going to go over two different ways you can get this same experience using O
 
 [OpenFaaS Cloud](https://github.com/openfaas/openfaas-cloud) offers you an integrated and automated experience, with a single push you can have your site deployed in seconds. You'll also get logs and metrics linked directly to your commit.
 
-If this sounds interesting to you check out the "one-click" [bootstrap tool](https://github.com/openfaas-incubator/ofc-bootstrap) to install OpenFaaS Cloud in less than 100 seconds or apply for an account on [The Community Cluster](https://github.com/openfaas/community-cluster) for free shared access.
+If this sounds interesting to you check out the "one-click" [bootstrap tool](https://github.com/openfaas/ofc-bootstrap) to install OpenFaaS Cloud in less than 100 seconds or apply for an account on [The Community Cluster](https://github.com/openfaas/community-cluster) for free shared access.
 
 In OpenFaaS Cloud by default we limit the templates that the users can use. This means we need to add the Hugo template before being able to deploy a function. To do this, edit the `git-tar` deployment in the `openfaas-fn` namespace and add the Hugo template URL `https://github.com/matipan/openfaas-hugo-template` to the `custom_templates` environment variable.
 

--- a/_posts/2019-09-05-eks-openfaas-cloud-build-guide.md
+++ b/_posts/2019-09-05-eks-openfaas-cloud-build-guide.md
@@ -79,7 +79,7 @@ Under the hood, OpenFaaS Cloud (OFC) will orchestrate OpenFaaS and Kubernetes to
 
 ## Start the tutorial
 
-I developed a tool along with the community called [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap) which installs all the requisite components like blocks of lego into a Kubernetes cluster. When you're finished you get a URL and can start linking both public and private repositories to enjoy automatic CI/CD. Within a few moments your endpoint will be accessible and published on the Internet.
+I developed a tool along with the community called [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap) which installs all the requisite components like blocks of lego into a Kubernetes cluster. When you're finished you get a URL and can start linking both public and private repositories to enjoy automatic CI/CD. Within a few moments your endpoint will be accessible and published on the Internet.
 
 Today we'll set up a Kubernetes cluster on AWS using `eksctl` and then after configuring a GitHub App for GitHub.com, we'll populate ofc-bootstrap's `init.yaml` file and run the tool. Configuring AWS and GitHub will take the majority of the time today, and if you're configuring these systems for the first time, it may take you a little longer.
 
@@ -87,7 +87,7 @@ Once you've prepared your AWS environment and GitHub configuration, the tool tak
 
 ### Overview of OpenFaaS Cloud components 
 
-![](https://raw.githubusercontent.com/openfaas-incubator/ofc-bootstrap/master/docs/ofc-bootstrap.png)
+![](https://raw.githubusercontent.com/openfaas/ofc-bootstrap/master/docs/ofc-bootstrap.png)
 
 `ofc-bootstrap` provides an opinionated configuration of OpenFaaS Cloud.
 
@@ -114,7 +114,7 @@ Official documentation exists for some of the tools we will use in this tutorial
 * Clone the repository
 
 ```sh
-git clone https://github.com/openfaas-incubator/ofc-bootstrap
+git clone https://github.com/openfaas/ofc-bootstrap
 cd ofc-bootstrap
 ```
 
@@ -347,7 +347,7 @@ The easiest registry to use is the [Docker Hub](https://hub.docker.com/), the ca
 
 You can also [install your own self-hosted registry](https://github.com/alexellis/k8s-tls-registry) for private Docker images. Note: you can self-host a registry on a single-node, or in a different cluster all together if you wish.
 
-> Note: using AWS ECR is beyond the scope of this tutorial. See here for info: [OFC: configuring AWS ECR](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md#prepare-your-docker-registry-if-using-aws-ecr).
+> Note: using AWS ECR is beyond the scope of this tutorial. See here for info: [OFC: configuring AWS ECR](https://github.com/openfaas/ofc-bootstrap/blob/master/USER_GUIDE.md#prepare-your-docker-registry-if-using-aws-ecr).
 
 Now log in, using ofc-bootstrap like indicated below:
 
@@ -414,7 +414,7 @@ For me the Plan executed in around 127 seconds (connecting from the UK) to an AW
 
 If the installation didn't work as expected try the following guides:
 
-* ofc-bootstrap README [troubleshooting section](https://github.com/openfaas-incubator/ofc-bootstrap).
+* ofc-bootstrap README [troubleshooting section](https://github.com/openfaas/ofc-bootstrap).
 
 * Troubleshooting guide for OpenFaaS Cloud in the [OpenFaaS docs](https://docs.openfaas.com/openfaas-cloud/self-hosted/troubleshoot/)
 
@@ -494,7 +494,7 @@ So if you would like to try OpenFaaS Cloud for development, but want to save on 
 
 Do you want to see a real-world example of what you can build? Check out my blog post on how to create a [Serverless Single Page App (SPA) with OFC, Postgres, Go and Vue.js](https://www.openfaas.com/blog/serverless-single-page-app/). You may also like [goodfirstissue bot](https://github.com/rajatjindal/goodfirstissue) which runs on The Community Cluster and is in active use by Google, CNCF (helm) and Jetstack.
 
-Contributions are also welcome to [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap)
+Contributions are also welcome to [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap)
 
 ### Thank you to OpenFaaS Ltd
 

--- a/_posts/2020-02-27-ofc-private-cloud.md
+++ b/_posts/2020-02-27-ofc-private-cloud.md
@@ -28,7 +28,7 @@ With your private cloud you'll be able to deploy microservices, APIs, blogs, wik
 
 * A private or public Kubernetes cluster with Intel architecture (ARM is not supported at this time) with at least 3x nodes with 4GB RAM and 2vCPU each
 
-> Note: if you are planning on using k3s, then you should see the [notes in the user-guide about disabling Traefik](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md)
+> Note: if you are planning on using k3s, then you should see the [notes in the user-guide about disabling Traefik](https://github.com/openfaas/ofc-bootstrap/blob/master/USER_GUIDE.md)
 
 * An account with DigitalOcean, AWS, GCP or Cloudflare for automatic DNS configuration and TLS
 
@@ -38,13 +38,13 @@ With your private cloud you'll be able to deploy microservices, APIs, blogs, wik
 
 Installed below:
 
-* Local tooling: kubectl, faas-cli, [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap) etc
+* Local tooling: kubectl, faas-cli, [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap) etc
 
 ## An overview
 
-The tool that we use to configure OpenFaaS Cloud (OFC) is [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap).
+The tool that we use to configure OpenFaaS Cloud (OFC) is [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap).
 
-![ofc-bootstrap tooling](https://github.com/openfaas-incubator/ofc-bootstrap/raw/master/docs/ofc-bootstrap.png)
+![ofc-bootstrap tooling](https://github.com/openfaas/ofc-bootstrap/raw/master/docs/ofc-bootstrap.png)
 
 > Note: that helm3 is now used, without Tiller.
 
@@ -71,13 +71,13 @@ Clone ofc-bootstrap and then install its CLI:
 ```bash
 mkdir -p ~/dev/
 cd ~/dev/
-git clone https://github.com/openfaas-incubator/ofc-bootstrap
+git clone https://github.com/openfaas/ofc-bootstrap
 cd ofc-bootstrap
 
-curl -sLSf https://raw.githubusercontent.com/openfaas-incubator/ofc-bootstrap/master/get.sh | sudo sh
+curl -sLSf https://raw.githubusercontent.com/openfaas/ofc-bootstrap/master/get.sh | sudo sh
 ```
 
-These instructions are also available in the [user guide](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md).
+These instructions are also available in the [user guide](https://github.com/openfaas/ofc-bootstrap/blob/master/USER_GUIDE.md).
 
 * [Download kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
@@ -274,7 +274,7 @@ slack:
 
 You can add additional overrides for the various features made available in example.init.yaml, including memory and CPU limits.
 
-See the [ofc-boostrap user-guide](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md) or the `example.init.yaml` file for more.
+See the [ofc-boostrap user-guide](https://github.com/openfaas/ofc-bootstrap/blob/master/USER_GUIDE.md) or the `example.init.yaml` file for more.
 
 ## Configure TLS and DNS
 
@@ -474,7 +474,7 @@ Are you an EKS user? We have a specific guide for you that covers IAM, Route53, 
 
 You can fork/star/browse the code on GitHub:
 
-* [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap)
+* [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap)
 * [openfaas-cloud](https://github.com/openfaas/openfaas-cloud)
 
 We also have a video recording from KubeCon covering some customer case-studies and community projects that are running on OpenFaaS Cloud: [OpenFaaS Cloud + Linkerd: A Secure, Multi-Tenant Serverless Platform - Charles Pretzer & Alex Ellis](https://www.youtube.com/watch?v=sD7hCwq3Gw0)

--- a/_posts/2020-04-22-continously-deploy-openfaas-cloud.md
+++ b/_posts/2020-04-22-continously-deploy-openfaas-cloud.md
@@ -41,18 +41,18 @@ easier and allow for tooling such as [FluxCD](https://github.com/fluxcd) to do s
 
 To follow along you will need the following things:
 
-* [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md#get-ofc-bootstrap) installed (Instructions in link)
+* [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap/blob/master/USER_GUIDE.md#get-ofc-bootstrap) installed (Instructions in link)
 * A [Keybase account](https://keybase.io/) (optional, but highly recommended for keeping secrets encrypted)
-* A Domain (We use `ofc.example.com`, replace this with your domain) managed by one of the [supported providers](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md#credentials-and-dependent-systems) (We are using AWS Route35)
+* A Domain (We use `ofc.example.com`, replace this with your domain) managed by one of the [supported providers](https://github.com/openfaas/ofc-bootstrap/blob/master/USER_GUIDE.md#credentials-and-dependent-systems) (We are using AWS Route35)
 * A set of credentials for AWS for ECR and Route53. (One for each)
- * the [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap) github repository checked out.
+ * the [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap) github repository checked out.
 
 ### Installing OpenFaaS Cloud
 
-The recommended installation method for OpenFaaS Cloud (OFC) is [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap/issues). 
+The recommended installation method for OpenFaaS Cloud (OFC) is [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap/issues). 
 It's a CLI that automates most of the configuration and installation of the OFC core components.
 
-![ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap/raw/master/docs/ofc-bootstrap.png)
+![ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap/raw/master/docs/ofc-bootstrap.png)
 
 > ofc-bootstrap packages a number of primitives such as an IngressController, a way to obtain certificates from LetsEncrypt, the OpenFaaS Cloud components, OpenFaaS itself and Minio for build log storage. Each component is interchangeable.
 
@@ -149,7 +149,7 @@ echo "admin" > credentials/basic-auth-user
 ofc-bootstrap registry-login --ecr --account-id <AWS_ACCOUNT_ID> --region <AWS_REGION>
 ```
 
-We are also using a `customers` file rather than a public url. This was released in version [0.9.2](https://github.com/openfaas-incubator/ofc-bootstrap/releases/tag/0.9.2)
+We are also using a `customers` file rather than a public url. This was released in version [0.9.2](https://github.com/openfaas/ofc-bootstrap/releases/tag/0.9.2)
 of `ofc-bootstrap` so make sure you are up to date to support these settings.
 
 ```bash


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This updates refs to ofc-bootstrap to point at the OpenFaaS org where it
now lives (moved from openfaas-incubator)

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Motivation and Context
ofc-boostrap has moved org

## Have you applied the editorial and style guide to your post?

N/A

## How have you tested the instructions for any tutorial steps?
N/A

## Types of changes

- [ ] New blog post
- [x] Updating an existing blog post
- [x] Updating part of the page page
- [ ] Adding a new web-page

## Checklist:

- [ ] I have given attribution for any images I have used and have permission to use them under Copyright law
- [ ] My code follows the [writing-style of the publication](README.md) and I have checked this
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
