### PR TITLE
Update members list for Alistair

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -5,9 +5,9 @@ founders:
 
 core:
   - lucas
+  - alistair
 
 members:
-  - alistair
   - vivek
   - utsav
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>


## Description
<!--- Describe your changes in detail -->

Add Alistair to the Core team

## Motivation and Context

The past year's worth of contributions and participation. Leadership demonstrated numerous areas including: in OpenFaaS Cloud and arkade.
