### PR TITLE
Update Flux post with new apiVersion for operator

### DIFF
--- a/_posts/2020-01-16-openfaas-flux.md
+++ b/_posts/2020-01-16-openfaas-flux.md
@@ -379,7 +379,7 @@ Edit certinfo and add the secret to the function definition:
 
 ```sh
 cat << EOF | tee functions/templates/certinfo.yaml
-apiVersion: openfaas.com/v1alpha2
+apiVersion: openfaas.com/v1
 kind: Function
 metadata:
   name: certinfo
@@ -466,7 +466,7 @@ Edit the generated YAML so that Flux can use Helm to control the version and lab
 
 ```sh
 cat << EOF | tee functions/templates/myfn.yaml
-apiVersion: openfaas.com/v1alpha2
+apiVersion: openfaas.com/v1
 kind: Function
 metadata:
   name: myfn


### PR DESCRIPTION
Signed-off-by: Simon Emms <simon@simonemms.com>


## Description
<!--- Describe your changes in detail -->
Add notification of new `apiVersion` for OpenFaaS operator

## Motivation and Context

Have run this setup with [a project I'm working on](https://github.com/foundry4/appeal-planning-decision/pull/290) and wanted to share my findings

## Have you applied the editorial and style guide to your post?

See the [README.md](README.md)

## How have you tested the instructions for any tutorial steps?

Yes

## Types of changes

- [ ] New blog post
- [x] Updating an existing blog post
- [ ] Updating part of the page page
- [ ] Adding a new web-page

## Checklist:

- [x] I have given attribution for any images I have used and have permission to use them under Copyright law
- [x] My code follows the [writing-style of the publication](README.md) and I have checked this
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
