### PR TITLE
Fix links to new OIDC Provider for OpenFaaS Pro

### DIFF
--- a/_posts/2019-08-29-five-security-tips.md
+++ b/_posts/2019-08-29-five-security-tips.md
@@ -37,7 +37,7 @@ Whatever plugin you decide to use, it's not just highly recommended, but essenti
 
 Compare: [OpenFaaS vs OpenFaaS Cloud](https://docs.openfaas.com/openfaas-cloud/intro/)
 
-See also: [Authentication in OpenFaaS](https://docs.openfaas.com/reference/authentication/)
+See also: [Authentication in OpenFaaS](https://docs.openfaas.com/reference/authentication/) and [Single Sign-on for OpenFaaS Pro](https://docs.openfaas.com/openfaas-pro/oidc-oauth2.md)
 
 Forgot your password? [Find it here](https://docs.openfaas.com/deployment/troubleshooting/)
 

--- a/_posts/2020-01-14-birthday-teamserverless.md
+++ b/_posts/2020-01-14-birthday-teamserverless.md
@@ -119,7 +119,7 @@ The first three products are:
 
 * [Commercial support](https://github.com/openfaas/faas/blob/master/BACKERS.md#sponsor-plus-packages) which offers backlog and PR prioritization, support via e-mail, and implementation of OpenFaaS / OpenFaaS Cloud.
 
-* [OIDC / OAuth2 plugin](https://docs.openfaas.com/reference/authentication/#oauth2-support-in-the-api-gateway-commercial-add-on)
+* [OIDC / OAuth2 plugin](https://docs.openfaas.com/openfaas-pro/oidc-oauth2.md)
 
     The plugin provides OIDC Connect / OAuth2 authentication for the gateway UI, CLI, and for CI/CD. It comes with first-class support for Auth0 and GitLab IDPs and has been used by some early customers to integrate with LDAP.
 

--- a/_posts/2020-09-16-openfaas-oidc-okta.md
+++ b/_posts/2020-09-16-openfaas-oidc-okta.md
@@ -20,7 +20,7 @@ Bring enterprise authentication and Single Sign-on (SSO) to OpenFaaS with Okta a
 
 OpenID Connect is a common standard that builds upon OAuth2 to enable authentication to services and applications. Solutions like [Okta](https://www.okta.com) can be used to enable Single Sign-On across a number of third-party and in-house applications. This reduces the burden on IT administrators - fewer requests to reset passwords, fewer employees will share credentials and policy can enforced in one place.
 
-In this tutorial, I'll show you how to setup Okta and [OpenFaaS with the OIDC / OAuth2 authentication module](https://docs.openfaas.com/reference/authentication/). The OIDC auth module for OpenFaaS is a commercial add-on included in our [OpenFaaS PRO Subscription](https://www.openfaas.com/support).
+In this tutorial, I'll show you how to setup Okta and [OpenFaaS with the OIDC / OAuth2 authentication module](https://docs.openfaas.com/openfaas-pro/oidc-oauth2.md). The OIDC auth module for OpenFaaS is a commercial add-on included in our [OpenFaaS PRO Subscription](https://www.openfaas.com/support).
 
 If you don't have an active [OpenFaaS PRO Subscription](https://www.openfaas.com/support), then you will need to apply for a trial key here: [Apply for a 14-day trial](https://forms.gle/mFmwtoez1obZzm286).
 
@@ -289,3 +289,4 @@ See also:
 * [Multiple namespace support](https://docs.openfaas.com/reference/namespaces/)
 * [Join the Slack community](https://slack.openfaas.io/)
 * [Authentication documentation](https://docs.openfaas.com/reference/authentication/)
+* [Single Sign-on with OpenFaaS Pro](https://docs.openfaas.com/openfaas-pro/oidc-oauth2.md)


### PR DESCRIPTION
This PR moves/adds links to the oidc provider which has moved to a new
path on the docs

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>


## Description
<!--- Describe your changes in detail -->

## Motivation and Context


## Have you applied the editorial and style guide to your post?

See the [README.md](README.md)

## How have you tested the instructions for any tutorial steps?


## Types of changes

- [ ] New blog post
- [x] Updating an existing blog post
- [ ] Updating part of the page page
- [ ] Adding a new web-page

## Checklist:

- [ ] I have given attribution for any images I have used and have permission to use them under Copyright law
- [ ] My code follows the [writing-style of the publication](README.md) and I have checked this
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
