### PR TITLE
Fix wrong template in command example

### DIFF
--- a/_posts/2020-11-19-openfaas-flask.md
+++ b/_posts/2020-11-19-openfaas-flask.md
@@ -86,7 +86,7 @@ To work with the HTTP request's headers such as the Method, Path or QueryString,
 export OPENFAAS_PREFIX=alexellis2
 export FN="http-headers"
 
-faas-cli new --lang python3-flask $FN
+faas-cli new --lang python3-http $FN
 ```
 
 Edit `./http-headers/handler.py`:


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

## Description
<!--- Describe your changes in detail -->
Fix wrong command example for `python-http` template.

## Motivation and Context
`faas-cli new` command for `python-http` example should use the correct template. 

## Have you applied the editorial and style guide to your post?

See the [README.md](README.md)

## How have you tested the instructions for any tutorial steps?


## Types of changes

- [ ] New blog post
- [x] Updating an existing blog post
- [ ] Updating part of an existing page
- [ ] Adding a new page

## Checklist:

- [ ] I have given attribution for any images I have used and have permission to use them under Copyright law
- [ ] My code follows the [writing-style of the publication](README.md) and I have checked this
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
