### PR TITLE
Add spacing between previous and next article links

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -74,10 +74,10 @@ layout: page
 
 		<div class="blog-navigation">
 			{% if page.previous.url %}
-				<a class="prev" href="{% include relative-src.html src=page.previous.url %}">&laquo; {{ page.previous.title }}</a>
+				<a class="prev" href="{% include relative-src.html src=page.previous.url %}">&laquo; {{ page.previous.title }}</a>&nbsp;
 			{% endif %}
 			{% if page.next.url %}
-				<a class="next" href="{% include relative-src.html src=page.next.url %}">{{ page.next.title }}&nbsp;&raquo;</a>
+				&nbsp;<a class="next" href="{% include relative-src.html src=page.next.url %}">{{ page.next.title }}&nbsp;&raquo;</a>
 			{% endif %}
 		</div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -77,7 +77,7 @@ layout: page
 				<a class="prev column" href="{% include relative-src.html src=page.previous.url %}">&laquo; {{ page.previous.title }}</a>
 			{% endif %}
 			{% if page.next.url %}
-				<a class="next column" href="{% include relative-src.html src=page.next.url %}">{{ page.next.title }}&raquo;</a>
+				<a class="next column" href="{% include relative-src.html src=page.next.url %}">{{ page.next.title }}&nbsp;&raquo;</a>
 			{% endif %}
 		</div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -72,12 +72,12 @@ layout: page
 		</div>
 		{% endif %}
 
-		<div class="blog-navigation">
+		<div class="blog-navigation columns">
 			{% if page.previous.url %}
-				<a class="prev" href="{% include relative-src.html src=page.previous.url %}">&laquo; {{ page.previous.title }}</a>&nbsp;
+				<a class="prev column" href="{% include relative-src.html src=page.previous.url %}">&laquo; {{ page.previous.title }}</a>
 			{% endif %}
 			{% if page.next.url %}
-				&nbsp;<a class="next" href="{% include relative-src.html src=page.next.url %}">{{ page.next.title }}&nbsp;&raquo;</a>
+				<a class="next column" href="{% include relative-src.html src=page.next.url %}">{{ page.next.title }}&raquo;</a>
 			{% endif %}
 		</div>
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1sJuNWgsynR7ZI4jX0EKUpCihE5vRbk%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=0lZhVOn)
Signed-off-by: avinashupadhya99 <avinashupadhya99@gmail.com>

## Description

Add spaces between the previous and next blog links at the end of each blog.

## Motivation and Context

There is no spacing between the previous and next blog links at the end of each blog.

Current - 
![image](https://user-images.githubusercontent.com/52544819/184390103-2fa3535e-a249-42bf-8f32-cb7303711b87.png)

Changes with PR -
![image](https://user-images.githubusercontent.com/52544819/184390186-d38628ba-4f92-4508-9b70-06bdb932d4ec.png)


## Have you applied the editorial and style guide to your post?

See the [README.md](README.md)

N/A

## How have you tested the instructions for any tutorial steps?

N/A

## Types of changes

- [ ] New blog post
- [ ] Updating an existing blog post
- [ ] Updating part of an existing page
- [ ] Adding a new page
- [x] Fixing layout

## Checklist:

- [x] I have given attribution for any images I have used and have permission to use them under Copyright law
- [x] My code follows the [writing-style of the publication](README.md) and I have checked this
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
