### PR TITLE
Add note on applying readiness for concurrency limits

### DIFF
--- a/_posts/2022-10-06-pdf-generation-at-scale-on-kubernetes.md
+++ b/_posts/2022-10-06-pdf-generation-at-scale-on-kubernetes.md
@@ -316,9 +316,14 @@ functions:
     image: welteki2/page-to-pdf:latest
     environment:
       max_inflight: 1
+    annotations:
+      com.openfaas.ready.http.path: /_/ready
 ```
-
 Note: after changing any value in an OpenFaaS YAML file, you must run `faas-cli deploy` for the change to take effect.
+
+When setting a concurrency limit on a function traffic may go to Pods which are overloaded, instead of Pods that are ready. To optimize throughput we can use the `com.openfaas.ready.http.path` annotation to configure a Kubernetes readiness probe for the `/_/ready` endpoint on our function. This way Kubernetes can route traffic away from the busy Pods which have reached the concurrency limit.
+
+> See also: [Custom health and readiness checks for your OpenFaaS Functions](https://www.openfaas.com/blog/health-and-readiness-for-functions/)
 
 ## Buffer and retry requests
 


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

## Description
<!--- Describe your changes in detail -->
Add a paragraph to the `Prevent overloading the function` section to explain applying readiness probes for concurrency limiting. Add a reference to the [Custom health and readiness checks for your OpenFaaS Functions](https://www.openfaas.com/blog/health-and-readiness-for-functions/) post.

## Motivation and Context
Improve the post and point users to additional OpenFaaS features to optimise this kind of workflow.

## Have you applied the editorial and style guide to your post?

See the [README.md](README.md)

## How have you tested the instructions for any tutorial steps?
Ran the docs site locally to verify the changes.

## Types of changes

- [ ] New blog post
- [x] Updating an existing blog post
- [ ] Updating part of an existing page
- [ ] Adding a new page

## Checklist:

- [ ] I have given attribution for any images I have used and have permission to use them under Copyright law
- [x] My code follows the [writing-style of the publication](README.md) and I have checked this
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
