### PR TITLE
Fix inconsistent Python indent on landing page

### DIFF
--- a/_includes/landing-page/code-examples/python.html
+++ b/_includes/landing-page/code-examples/python.html
@@ -9,5 +9,5 @@ $ faas-cli new --lang python3-http python3-fn
     return {
         "statusCode": 200,
         "body": "Hello from OpenFaaS!"
-}</code></pre>
+    }</code></pre>
 </div>


### PR DESCRIPTION
## Description
Add missing whitespaces in Python example to make code on landing page more consistent and Pythonic

## Motivation and Context
Python example at [landing page](https://www.openfaas.com) has inconsistent indent

Due to [PEP8](https://peps.python.org/pep-0008/#indentation):

The closing brace/bracket/parenthesis on multiline constructs may either line up under the first non-whitespace character of the last line of list, as in:

```python3
my_list = [
    1, 2, 3,
    4, 5, 6,
    ]
result = some_function_that_takes_arguments(
    'a', 'b', 'c',
    'd', 'e', 'f',
    )
```

or it may be lined up under the first character of the line that starts the multiline construct, as in:

```python3
my_list = [
    1, 2, 3,
    4, 5, 6,
]
result = some_function_that_takes_arguments(
    'a', 'b', 'c',
    'd', 'e', 'f',
)
```

## Types of changes

- [ ] New blog post
- [ ] Updating an existing blog post
- [X] Updating part of an existing page
- [ ] Adding a new page

## Checklist:

- [X] I have given attribution for any images I have used and have permission to use them under Copyright law
- [X] My code follows the [writing-style of the publication](README.md) and I have checked this
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
