### PR TITLE
Fix tooltip for functions deployment limit in OpenFaaS Standard pricing card

### DIFF
--- a/_includes/pricing-page/pricing-cards.html
+++ b/_includes/pricing-page/pricing-cards.html
@@ -168,7 +168,7 @@
                                 <path d="M1412 734q0-28-18-46l-91-90q-19-19-45-19t-45 19l-408 407-226-226q-19-19-45-19t-45 19l-91 90q-18 18-18 46 0 27 18 45l362 362q19 19 45 19 27 0 46-19l543-543q18-18 18-45zm252 162q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z">
                                 </path>
                             </svg>
-                            <span data-tooltip="You can deploy 500 functions before requiring a license to upgrade to OpenFaaS Standard">500x functions</span>
+                            <span data-tooltip="You can deploy 500 functions before requiring a license to upgrade to OpenFaaS for Enterprises">500x functions</span>
                         </li>
                         <li class="mb-3 is-flex is-align-items-center">
                             <svg class="image is-24x24 mr-2" xmlns="http://www.w3.org/2000/svg"stroke="currentColor" fill="#10b981" viewBox="0 0 1792 1792">


### PR DESCRIPTION
## Description
Update the text displayed in the tooltip for the "Functions" limit on the pricing page.

## Motivation and Context
This change ensures that visitors have access to accurate information. The previous tooltip text was inaccurate and did not reflect the requirement for upgrading to "OpenFaaS for Enterprises" (15 is the functions deployment limit for CE and 500 for Standard Edition).

## Have you applied the editorial and style guide to your post?

See the [README.md](README.md)

## How have you tested the instructions for any tutorial steps?

## Types of changes

- [ ] New blog post
- [ ] Updating an existing blog post
- [X] Updating part of an existing page
- [ ] Adding a new page

## Checklist:

- [X] I have given attribution for any images I have used and have permission to use them under Copyright law
- [X] My code follows the [writing-style of the publication](README.md) and I have checked this
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
