### PR TITLE
Add GCP Pub/Sub connector to pricing table

### DIFF
--- a/_includes/landing-page/landing-description.html
+++ b/_includes/landing-page/landing-description.html
@@ -63,7 +63,7 @@
                                 Event-driven workloads
                             </h2>
                             <p class="title has-text-weight-light is-size-5-tablet is-size-4 has-text-grey">
-                                Invoke functions through events from Apache Kafka, AWS SQS, Postgresql, Cron and MQTT. 
+                                Invoke functions through events from Apache Kafka, AWS SQS/SNS, GCP Pub/Sub, RabbitMQ, Postgresql, Cron and MQTT. 
                             </p>
                         </div>
                     </div>

--- a/_includes/pricing-page/pricing-cards.html
+++ b/_includes/pricing-page/pricing-cards.html
@@ -219,7 +219,7 @@
                                 <path d="M1412 734q0-28-18-46l-91-90q-19-19-45-19t-45 19l-408 407-226-226q-19-19-45-19t-45 19l-91 90q-18 18-18 46 0 27 18 45l362 362q19 19 45 19 27 0 46-19l543-543q18-18 18-45zm252 162q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z">
                                 </path>
                             </svg>
-                            Kafka, RabbitMQ, Postgresql, AWS SNS/SQS triggers
+                            Kafka, RabbitMQ, GCP Pub/Sub, Postgresql, AWS SNS/SQS triggers
                         </li>
 
                         <li class="mb-3 is-flex is-align-items-center ">

--- a/_includes/pricing-page/pricing-table.html
+++ b/_includes/pricing-page/pricing-table.html
@@ -344,6 +344,12 @@
                 <td class="is-2">{% include yes.html %}</td>
                 <td class="is-2">{% include yes.html %}</td>
             </tr>
+            <tr>
+                <th class="is-one-third">Google Cloud Pub/Sub</th>
+                <td class="is-2">{% include no.html %}</td>
+                <td class="is-2">{% include yes.html %}</td>
+                <td class="is-2">{% include yes.html %}</td>
+            </tr>
 
             <tr>
                 <td colspan="4">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add GCP Pub/Sub connector to pricing table.

<img width="1369" alt="Screenshot 2025-04-02 at 16 22 49" src="https://github.com/user-attachments/assets/f2f2b514-f30e-4756-b6dd-8ad0fad27c2e" />

## Motivation and Context

Show Google Cloud Pub/Sub connector is available for OpenFaaS Pro.

## Have you applied the editorial and style guide to your post?

See the [README.md](README.md)

## How have you tested the instructions for any tutorial steps?



## Types of changes

- [ ] New blog post
- [ ] Updating an existing blog post
- [x] Updating part of an existing page
- [ ] Adding a new page

## Checklist:

- [x] I have given attribution for any images I have used and have permission to use them under Copyright law
- [x] My code follows the [writing-style of the publication](README.md) and I have checked this
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
