### PR TITLE
Update email filter example to use OpenAI Responses API

### DIFF
--- a/_posts/2025-04-11-filter-emails-with-openai.md
+++ b/_posts/2025-04-11-filter-emails-with-openai.md
@@ -481,21 +481,19 @@ If the email is incomplete or ambiguous, base your judgment on available content
 Email:
 ```
 
-The classification function shown below constructs the full prompt dynamically based on the email content and sends it to the OpenAI Chat API using the `gpt-3.5-turbo` model:
+The classification function shown below constructs the full prompt dynamically based on the email content and sends it to the OpenAI Responses API using the `gpt-5.4-nano` model:
 
 ```python
 def classify_email_content(prompt, content):
     full_prompt = f"{prompt}\n\nFrom: {content['from']}\nSubject: {content['subject']}\nBody:\n{content['body']}"
-    response = openAIClient.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=[
-            {"role": "system", "content": "You are an assistant that classifies emails. Always respond with JSON."},
-            {"role": "user", "content": full_prompt}
-        ],
+    response = openAIClient.responses.create(
+        model="gpt-5.4-nano",
+        instructions="You are an assistant that classifies emails. Always respond with JSON.",
+        input=full_prompt,
         temperature=0.2,  # Low randomness for consistent output
-        max_tokens=300
+        max_output_tokens=300
     )
-    return response.choices[0].message.content
+    return response.output_text
 ```
 
 When implementing your own version of the function feel free to experiment with different available models. The prompt we use in this example is very minimal and you might want to give it more context and examples for a more reliable and consistent output. OpenAI also has a great article on [how to optimize the correctness and accuracy of an LLM for specific tasks](https://platform.openai.com/docs/guides/optimizing-llm-accuracy).


### PR DESCRIPTION
## Description
Switch the `classify_email_content` code example from the Chat Completions API
to the Responses API, update the model to `gpt-5.4-nano`, and update the
surrounding prose to match.

## Motivation and Context
The Responses API is OpenAI's recommended API for all new projects. Chat
Completions remains supported but should not be used in new examples.

## Have you applied the editorial and style guide to your post?
Yes.

## How have you tested the instructions for any tutorial steps?
A similar change has been tested in the OpenFaaS docs Python OpenAI example
for calling the OpenAI API.

## Types of changes

- [ ] New blog post
- [x] Updating an existing blog post
- [ ] Updating part of an existing page
- [ ] Adding a new page

## Checklist:

- [ ] I have given attribution for any images I have used and have permission to use them under Copyright law
- [x] My code follows the writing-style of the publication and I have checked this
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with `git commit -s`